### PR TITLE
Fix a possible typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1149,7 +1149,7 @@ In general, **all Xcode warnings should not be ignored**. These include things l
 <tr>
 <td><pre lang=swift>
 let leftMargin: CGFloat = 20
-view.frame.x = 20
+view.frame.x = leftMargin
 </pre></td>
 <td><pre lang=swift>
 view.frame.x = 20 // left margin

--- a/README_jp.md
+++ b/README_jp.md
@@ -1148,7 +1148,7 @@ class BaseViewController: UIViewController {
 <tr>
 <td><pre lang=swift>
 let leftMargin: CGFloat = 20
-view.frame.x = 20
+view.frame.x = leftMargin
 </pre></td>
 <td><pre lang=swift>
 view.frame.x = 20 // left margin


### PR DESCRIPTION
`leftMargin` is defined but not used in an example.

(Thank you for sharing the great practices.)